### PR TITLE
Change DHCP lease time to 1 hr when device settings deleted

### DIFF
--- a/resource_device_settings.go
+++ b/resource_device_settings.go
@@ -350,7 +350,7 @@ func resourceDeviceSettingsDelete(ctx context.Context, d *schema.ResourceData, m
 	network0["advertise"] = true
 	network0["override"] = false
 
-	dhcp["enabled"] = true
+	dhcp["leaseTimeSeconds"] = 3600
 	dhcp["override"] = false
 
 	for _, v := range interfaces {


### PR DESCRIPTION
When deleting a device settings resource, it would complain that the `leaseTimeSeconds` was invalid.

This removes the enabing DHCP option as the override isn't applied anyway.

This adds in a default lease time of `3600` seconds to stop the API complaining.